### PR TITLE
Aligned the text displaying Course Professor & Related Careers

### DIFF
--- a/Education_Pathways/frontend/src/components/css/course-description.css
+++ b/Education_Pathways/frontend/src/components/css/course-description.css
@@ -73,6 +73,7 @@ p {
 
 .course-template .course-description, .course-requisite, course-professor, course-relatedcareers {
   margin-left: 0;
+  text-align: center;
 }
 
 .requisites-display {


### PR DESCRIPTION
Updated course-description.css to align text to the center- However the data for course professor & related careers is not showing up on the course page. 